### PR TITLE
regarding blast hits: fixed a problem displaying them, also allowed more time to compute them

### DIFF
--- a/graph/debruijnnode.cpp
+++ b/graph/debruijnnode.cpp
@@ -399,22 +399,21 @@ std::vector<BlastHitPart> DeBruijnNode::getBlastHitPartsForThisNodeOrReverseComp
     if (m_number < 0)
         std::swap(positiveNode, negativeNode);
 
-    //Look for blast hit parts on the positive node first.  If none are found,
-    //then try the negative node.
+    //Look for blast hit parts on both the positive and the negative node,
+    // since hits were previously filtered such that startPos < endPos,
+    // hence we need to look at both positive and negative nodes to recover all hits.
     std::vector<BlastHitPart> returnVector;
     for (size_t i = 0; i < positiveNode->m_blastHits.size(); ++i)
     {
         std::vector<BlastHitPart> hitParts = positiveNode->m_blastHits[i]->getBlastHitParts(false);
         returnVector.insert(returnVector.end(), hitParts.begin(), hitParts.end());
     }
-    if (returnVector.size() == 0)
-    {
-        for (size_t i = 0; i < negativeNode->m_blastHits.size(); ++i)
+        
+    for (size_t i = 0; i < negativeNode->m_blastHits.size(); ++i)
         {
             std::vector<BlastHitPart> hitParts = negativeNode->m_blastHits[i]->getBlastHitParts(true);
             returnVector.insert(returnVector.end(), hitParts.begin(), hitParts.end());
         }
-    }
 
     return returnVector;
 }

--- a/ui/blastsearchdialog.cpp
+++ b/ui/blastsearchdialog.cpp
@@ -359,7 +359,9 @@ void BlastSearchDialog::runBlastSearch()
     QString fullBlastnCommand = m_blastnCommand + " -query " + g_tempDirectory + "queries.fasta -db " + g_tempDirectory + "all_nodes.fasta -outfmt 6 " + extraCommandLineOptions;
 
     blastn.start(fullBlastnCommand);
-    blastn.waitForFinished();
+
+    int timeOutMs = 90000;// wait up to 90 seconds (default is 30 seconds for waitForFinished)
+    blastn.waitForFinished(timeOutMs); 
 
     QString blastHits = blastn.readAll();
 


### PR DESCRIPTION
Hi Ryan,

I found a bug when displaying blast hits in "Single" node style. Many hits were not reported, e.g. a reverse-complemented contig which matched full-length to a reference was not reported; turns out the corresponding forward contig had a few small matches.

The cause: hits were filtered such that startPos < endPos, and negative hits were not displayed whenever there existed at least one positive hit.

Also, I'm attaching a commit which raises Blast computation time to 90 seconds instead of 30 seconds, because of a timeout on my machine on  larger assemblies. Ideally this could be a tuneable parameter.